### PR TITLE
reslove - 17 실시간 접속자 구현

### DIFF
--- a/src/main/java/com/realtimedocument/demo/SubscriptionInterceptor.java
+++ b/src/main/java/com/realtimedocument/demo/SubscriptionInterceptor.java
@@ -1,0 +1,45 @@
+package com.realtimedocument.demo;
+
+import com.realtimedocument.demo.service.SubscriptionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SubscriptionInterceptor implements ChannelInterceptor {
+    private final SubscriptionService subscriptionService;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        // STOMP 메시지를 래핑하여 헤더에 접근할 수 있게 함
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+//        String sessionId = accessor.getSessionId();
+        String userEmail = accessor.getFirstNativeHeader("userEmail");
+
+        // STOMP 명령어에 따라 다른 작업 수행
+        if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+            String destination = accessor.getDestination();
+            // 문서에 대한 경로일 경우 구독 정보 추가
+            if (destination != null && destination.matches("/sub/workspace/[0-9a-fA-F-]{36}/subscribers")) {
+                subscriptionService.addSubscription(destination, userEmail);
+            }
+        } else if (StompCommand.UNSUBSCRIBE.equals(accessor.getCommand())) {
+            // 커스텀 헤더에서 destination 읽기
+            String destination = accessor.getFirstNativeHeader("destination");
+            // 구독 해제 또는 연결 해제
+            if (destination != null && destination.matches("/sub/workspace/[0-9a-fA-F-]{36}/subscribers")) {
+                subscriptionService.removeSubscription(destination, userEmail);
+            }
+        } else if (StompCommand.DISCONNECT.equals(accessor.getCommand())) {
+            subscriptionService.removeAllSubscriptions(userEmail);
+        }
+
+        // 메시지를 채널로 전달
+        return message;
+    }
+}

--- a/src/main/java/com/realtimedocument/demo/WebSocketConfig.java
+++ b/src/main/java/com/realtimedocument/demo/WebSocketConfig.java
@@ -1,14 +1,20 @@
 package com.realtimedocument.demo;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer{
+
+	private final SubscriptionInterceptor subscriptionInterceptor;
 
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) { 
@@ -21,5 +27,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer{
 	public void configureMessageBroker(MessageBrokerRegistry config) {
 		config.setApplicationDestinationPrefixes("/pub");
 		config.enableSimpleBroker("/sub");
+	}
+
+	@Override
+	public void configureClientInboundChannel(ChannelRegistration registration) {
+		registration.interceptors(subscriptionInterceptor);
 	}
 }

--- a/src/main/java/com/realtimedocument/demo/controller/StompController.java
+++ b/src/main/java/com/realtimedocument/demo/controller/StompController.java
@@ -1,6 +1,7 @@
 package com.realtimedocument.demo.controller;
 
 import com.realtimedocument.demo.model.WorkspaceDoc;
+import com.realtimedocument.demo.service.SubscriptionService;
 import com.realtimedocument.demo.service.TextBlockService;
 import org.json.JSONObject;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
@@ -14,8 +15,10 @@ import com.realtimedocument.demo.model.Workspace;
 import com.realtimedocument.demo.service.WorkspaceService;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.List;
+import java.util.Set;
 
 @Controller
 @RequiredArgsConstructor
@@ -24,6 +27,7 @@ public class StompController {
 	private final SimpMessagingTemplate messageTemplate;
 	private final WorkspaceService workspaceService;
 	private final TextBlockService textBlockService;
+	private final SubscriptionService subscriptionService;
 
 	// 워크스페이스별 웹소켓 연결 :: 워크스페이스 삭제 + 문서 생성, 삭제
 	@MessageMapping("/workspace")
@@ -32,6 +36,15 @@ public class StompController {
 		return message;
 	}
 
+	// 워크스페이스 접속자 목록
+	@MessageMapping("/workspace/{wsId}/subscribers")
+	@SendTo("/sub/workspace/{wsId}/subscribers")
+	public Set<String> getSubscribers(@DestinationVariable("wsId") String wsId) {
+		System.out.println("**새로운 접속자 연결됨**");
+		String documentPath = "/sub/workspace/" + wsId + "/subscribers";
+		System.out.println(subscriptionService.getSubscribers(documentPath));
+		return subscriptionService.getSubscribers(documentPath);
+	}
 
 	// 워크스페이스 -> 문서별 웹소켓 연결 :: 텍스트 블록 생성, 수정, 삭제
 	@MessageMapping("/workspace/{wsId}/document/{docId}")

--- a/src/main/java/com/realtimedocument/demo/service/SubscriptionService.java
+++ b/src/main/java/com/realtimedocument/demo/service/SubscriptionService.java
@@ -1,0 +1,42 @@
+package com.realtimedocument.demo.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+public class SubscriptionService {
+    // 구독 경로에 대한 아이디 저장
+    private final Map<String, Set<String>> subscriptions = new HashMap<>();
+
+    // 새로운 문서를 선택할 때 이 메서드가 호출
+    public void addSubscription(String documentPath, String userEmail) {
+        subscriptions.computeIfAbsent(documentPath, k -> new HashSet<>()).add(userEmail);
+        System.out.println("**구독** >> " + subscriptions);
+    }
+
+    // 다른 문서를 선택하거나 페이지를 닫을 때 이 메서드가 호출
+    public void removeSubscription(String documentPath, String userEmail) {
+        Set<String> userEmails = subscriptions.get(documentPath);
+        if (userEmails != null) {
+            userEmails.remove(userEmail);
+            System.out.println("**구독해제** >> " + subscriptions);
+            if (userEmails.isEmpty()) {
+                subscriptions.remove(documentPath);
+            }
+        }
+    }
+
+    public Set<String> getSubscribers(String documentPath) {
+        System.out.println(subscriptions);
+        return subscriptions.getOrDefault(documentPath, new HashSet<>());
+    }
+
+    // 연결이 끊어질 때 모든 구독 제거
+    public void removeAllSubscriptions(String userEmail) {
+        for (Set<String> subscribers : subscriptions.values()) {
+            subscribers.remove(userEmail);
+        }
+        subscriptions.entrySet().removeIf(entry -> entry.getValue().isEmpty());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,9 +5,9 @@ server.port=0
 
 # Spring DataSource (MySQL)
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://ls-3a838c1167165730c95d3cb3c582052c82b6eff0.c1o02m0s40y4.ap-northeast-2.rds.amazonaws.com:3306/dbmaster?useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC
-spring.datasource.username=dbmasteruser
-spring.datasource.password=cooper-doc
+spring.datasource.url=????
+spring.datasource.username=????
+spring.datasource.password=????
 
 # Spring JPA
 spring.jpa.database=mysql


### PR DESCRIPTION
<실시간 접속자 구현>
- 접속자 단위는 문서 단위가 아닌 워크스페이스 단위로 한다.
- 로그인을 한 이후에 전체 유저 목록을 받아와 저장한다.
- 이후 워크스페이스를 선택할 때마다 워크스페이스 접속자 경로를 구독한다.
- 접속자는 문서 서버에서 관리된다.
- 접속자는 실시간 갱신되나 전체 유저 정보는 메인 화면이 로딩될 때만 갱신된다.